### PR TITLE
opticalphoton workaround and allow_pickle fix

### DIFF
--- a/root_utils/np_to_digihit_array_hdf5.py
+++ b/root_utils/np_to_digihit_array_hdf5.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         print(input_file, flush=True)
         if not os.path.isfile(input_file):
             raise ValueError(input_file+" does not exist")
-        npz_file = np.load(input_file)
+        npz_file = np.load(input_file, allow_pickle=True)
         trigger_times = npz_file['trigger_time']
         trigger_types = npz_file['trigger_type']
         hit_triggers = npz_file['digi_hit_trigger']

--- a/root_utils/np_to_truehit_array_hdf5.py
+++ b/root_utils/np_to_truehit_array_hdf5.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
         print(input_file, flush=True)
         if not os.path.isfile(input_file):
             raise ValueError(input_file+" does not exist")
-        npz_file = np.load(input_file)
+        npz_file = np.load(input_file, allow_pickle=True)
         hit_pmts = npz_file['true_hit_pmt']
         total_rows += hit_pmts.shape[0]
         for h in hit_pmts:

--- a/root_utils/root_file_utils.py
+++ b/root_utils/root_file_utils.py
@@ -102,6 +102,25 @@ class WCSim:
                 "direction": [p / norm for p in momentum],
                 "energy": sum(p.GetE() for p in particles)
             }
+
+        # Workaround for opticalphoton shotgun sim (Ka Ming's)
+        opticalphotons = [t for t in tracks if t.GetFlag() == -2]  # Flag==-1 doesn't have proper position
+        if len(opticalphotons) == 1 and opticalphotons[0].GetIpnu() == 0:
+            position = [opticalphotons[0].GetStop(i) for i in range(3)] 
+            
+        opticalphotons = [t for t in tracks if t.GetFlag() == -1]     
+        if len(opticalphotons) == 1 and opticalphotons[0].GetIpnu() == 0:
+            direction = [opticalphotons[0].GetDir(i) for i in range(3)]
+            energy = opticalphotons[0].GetE()
+            
+            #print(position, direction, energy)
+            return {
+                "pid": -22,
+                "position": position,
+                "direction": direction,
+                "energy": energy
+            }
+            
         # Otherwise something else is going on... guess info from the primaries
         momentum = [sum(p.GetDir(i) * p.GetP() for p in particles) for i in range(3)]
         norm = np.sqrt(sum(p ** 2 for p in momentum))

--- a/root_utils/root_file_utils.py
+++ b/root_utils/root_file_utils.py
@@ -103,7 +103,7 @@ class WCSim:
                 "energy": sum(p.GetE() for p in particles)
             }
 
-        # Workaround for opticalphoton shotgun sim (Ka Ming's)
+        # Workaround for opticalphoton sim
         opticalphotons = [t for t in tracks if t.GetFlag() == -2]  # Flag==-1 doesn't have proper position
         if len(opticalphotons) == 1 and opticalphotons[0].GetIpnu() == 0:
             position = [opticalphotons[0].GetStop(i) for i in range(3)] 
@@ -113,7 +113,6 @@ class WCSim:
             direction = [opticalphotons[0].GetDir(i) for i in range(3)]
             energy = opticalphotons[0].GetE()
             
-            #print(position, direction, energy)
             return {
                 "pid": -22,
                 "position": position,


### PR DESCRIPTION
WCSim doesn't store optical photons in the usual particle stack, so get info from tracks instead.